### PR TITLE
executeResource had incorrect @NonNullable annotation

### DIFF
--- a/src/main/java/com/arm/mbed/cloud/sdk/Connect.java
+++ b/src/main/java/com/arm/mbed/cloud/sdk/Connect.java
@@ -511,7 +511,7 @@ public class Connect extends AbstractApi {
      */
     @API
     public @Nullable Object executeResource(@NonNull String deviceId, @NonNull String resourcePath,
-            @NonNull String functionName, @DefaultValue(value = FALSE) boolean noResponse, @Nullable TimePeriod timeout)
+            @Nullable String functionName, @DefaultValue(value = FALSE) boolean noResponse, @Nullable TimePeriod timeout)
             throws MbedCloudException {
         final String id = deviceId;
         final String path = resourcePath;


### PR DESCRIPTION
`executeResourceAsync`'s parameter `functionName` is `@Nullable`

`executeResource` directly calls `executeResourceAsync` yet `functionName` in `executeResource` is `@NonNullable`.

Shouldn't the function signature in `executeResource` match `executeResourceAsync`?